### PR TITLE
Update PolicySettingValue type

### DIFF
--- a/api/v1alpha1/action_behavior.go
+++ b/api/v1alpha1/action_behavior.go
@@ -21,13 +21,14 @@ type ActionMode string
 const (
 	Automatic ActionMode = "Automatic"
 	Manual    ActionMode = "Manual"
+	Recommend ActionMode = "Recommend"
 	Disabled  ActionMode = "Disabled"
 )
 
 // ActionBehavior defines the action type and its corresponding mode
 type ActionBehavior struct {
 	// The Action mode of HorizontalScaleUp action
-	// +kubebuilder:validation:Enum=Automatic;Manual;Disabled
+	// +kubebuilder:validation:Enum=Automatic;Manual;Recommend;Disabled
 	// +optional
 	HorizontalScaleUp ActionMode `json:"scaleUp,omitempty"`
 

--- a/api/v1alpha1/policy_setting.go
+++ b/api/v1alpha1/policy_setting.go
@@ -16,24 +16,17 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-)
-
-type PolicySettingName string
+import v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 const (
-	ResponseTime PolicySettingName = "ResponseTime"
-	Transaction  PolicySettingName = "Transaction"
+	ResponseTime = "ResponseTime"
+	Transaction  = "Transaction"
 )
-
-type PolicySettingValue *v1.JSON
 
 type PolicySetting struct {
 	// The name of the policy setting
-	// +kubebuilder:validation:Enum=ResponseTime;Transaction
-	Name PolicySettingName `json:"name"`
+	Name string `json:"name"`
 
 	// The value of the policy setting
-	Value PolicySettingValue `json:"value"`
+	Value v1.JSON `json:"value"`
 }

--- a/config/crd/bases/policy.turbonomic.io_slohorizontalscales.yaml
+++ b/config/crd/bases/policy.turbonomic.io_slohorizontalscales.yaml
@@ -84,9 +84,6 @@ spec:
                   properties:
                     name:
                       description: The name of the policy setting
-                      enum:
-                      - ResponseTime
-                      - Transaction
                       type: string
                     value:
                       description: The value of the policy setting

--- a/config/crd/bases/policy.turbonomic.io_slohorizontalscales.yaml
+++ b/config/crd/bases/policy.turbonomic.io_slohorizontalscales.yaml
@@ -56,6 +56,7 @@ spec:
                     enum:
                     - Automatic
                     - Manual
+                    - Recommend
                     - Disabled
                     type: string
                 type: object

--- a/config/samples/policy_v1alpha1_policybinding.yaml
+++ b/config/samples/policy_v1alpha1_policybinding.yaml
@@ -1,11 +1,15 @@
+# This is an example of PolicyBinding that specifies an SLOHorizontalScale
+# policy and the target services that the policy applies to
 apiVersion: policy.turbonomic.io/v1alpha1
 kind: PolicyBinding
 metadata:
   name: policy-binding-sample
 spec:
+  # The reference to the SLOHorizontalScale policy
   policyRef:
     kind: SLOHorizontalScale
     name: slo-horizontal-scale-sample
+  # The target services that the policy applies to
   targets:
     - apiVersion: apps/v1
       kind: Service

--- a/config/samples/policy_v1alpha1_slohorizontalscale.yaml
+++ b/config/samples/policy_v1alpha1_slohorizontalscale.yaml
@@ -1,15 +1,20 @@
+# This is an example of SLOHorizontalScale policy
 apiVersion: policy.turbonomic.io/v1alpha1
 kind: SLOHorizontalScale
 metadata:
   name: slo-horizontal-scale-sample
 spec:
+  # The minimum number of replicas of a service
   minReplicas: 1
+  # The maximum number of replicas of a service
   maxReplicas: 10
+  # The objectives of this SLOHorizontalScale policy
   objectives:
     - name: ResponseTime
       value: 300
     - name: Transaction
       value: 20
+  # The behavior of SLO driven horizontal scale actions
   behavior:
     scaleUp: Automatic
     scaleDown: Disabled


### PR DESCRIPTION
## Problem
Currently `PolicySettingVaue` is set to the type of `v1.JSON`, which is equivalent to the type `Raw []byte`, this is to support  any possible policy setting value types such as `bool`, `int64`, `float64` and `string`. However this results in controller runtime client failure like the following while listing or getting the `SLOHorizontalScale` resource:

```
E0606 20:49:59.427985   72138 cluster_info_scraper.go:493] Failed to get slo scale json: cannot unmarshal number into Go struct field PolicySetting.items.spec.objectives.value of type v1alpha1.PolicySettingValue
```

## Solution
It seems that directly defining `PolicySetting.Value` as `v1.JSON` resolves the issue. Defining a new `PolicySettingValue` type does not seem to work.

## Test
Verified in `kubeturbo`:

```
    Spec: (v1alpha1.SLOHorizontalScaleSpec) {
      MinReplicas: (int32) 1,
      MaxReplicas: (int32) 10,
      Objectives: ([]v1alpha1.PolicySetting) (len=2) {
        (v1alpha1.PolicySetting) {
          Name: (string) (len=12) "ResponseTime",
          Value: (v1.JSON) &JSON{Raw:*[51 48 48 46 49],}
        },
        (v1alpha1.PolicySetting) {
          Name: (string) (len=11) "Transaction",
          Value: (v1.JSON) &JSON{Raw:*[50 48],}
        }
      },
      Behavior: (v1alpha1.ActionBehavior) {
        HorizontalScaleUp: (v1alpha1.ActionMode) (len=9) "Automatic",
        HorizontalScaleDown: (v1alpha1.ActionMode) (len=8) "Disabled"
      }
    },
    Status: (v1alpha1.SLOHorizontalScaleStatus) {
    }
```