### PR TITLE
Better support for optional settings

### DIFF
--- a/api/v1alpha1/action_behavior.go
+++ b/api/v1alpha1/action_behavior.go
@@ -30,10 +30,10 @@ type ActionBehavior struct {
 	// The Action mode of HorizontalScaleUp action
 	// +kubebuilder:validation:Enum=Automatic;Manual;Recommend;Disabled
 	// +optional
-	HorizontalScaleUp ActionMode `json:"scaleUp,omitempty"`
+	HorizontalScaleUp *ActionMode `json:"scaleUp,omitempty"`
 
 	// The Action mode of HorizontalScaleDown action
 	// +kubebuilder:validation:Enum=Automatic;Manual;Disabled
 	// +optional
-	HorizontalScaleDown ActionMode `json:"scaleDown,omitempty"`
+	HorizontalScaleDown *ActionMode `json:"scaleDown,omitempty"`
 }

--- a/api/v1alpha1/slohorizontalscale_types.go
+++ b/api/v1alpha1/slohorizontalscale_types.go
@@ -27,14 +27,14 @@ type SLOHorizontalScaleSpec struct {
 	// +kubebuilder:validation:Maximum=10000
 	// +kubebuilder:default:=1
 	// +optional
-	MinReplicas int32 `json:"minReplicas,omitempty"`
+	MinReplicas *int32 `json:"minReplicas,omitempty"`
 
 	// The maximum number of replicas of a service
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=10000
 	// +kubebuilder:default:=10000
 	// +optional
-	MaxReplicas int32 `json:"maxReplicas,omitempty"`
+	MaxReplicas *int32 `json:"maxReplicas,omitempty"`
 
 	// The objectives of this SLOHorizontalScale policy
 	// +kubebuilder:default:={{name:ResponseTime,value:2000},{name:Transaction,value:10}}


### PR DESCRIPTION
This PR makes certain policy setting value a pointer to better support optional values. 
When `kubeturbo` discovers `nil` value, it does not need to create a setting, and default value can be used in the Platform.